### PR TITLE
Update typings to include Flags.context

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,86 +3,92 @@ export function script(options?: ScriptOptions): Script;
 export const assertions: any;
 
 interface Script {
-  after: After,
-  afterEach: After,
-  before: Before,
-  beforeEach: Before
-  describe: Experiment,
-  experiment: Experiment,
-  suite: Experiment,
-  it: Test,
-  test: Test,
-  expect(value: any): any
+  after: After;
+  afterEach: After;
+  before: Before;
+  beforeEach: Before;
+  describe: Experiment;
+  experiment: Experiment;
+  suite: Experiment;
+  it: Test;
+  test: Test;
+  expect(value: any): any;
 }
 
 interface Options {
   /** number of ms to wait for test/experiment to execute */
-  timeout?: number
+  timeout?: number;
 }
 
 interface Plan {
   /** number of assertions expected to execute */
-  plan?: number
+  plan?: number;
+}
+
+interface OperationFlags {
+  context: Record<string, any>;
 }
 
 interface Operation {
-  <T>(): Promise<T> | void,
-  (): void
+  <T>(flags: OperationFlags): Promise<T> | void;
+  (flags: OperationFlags): void;
 }
 
-interface Flags {
-  note(note: string): void,
-  onCleanup(operation: Operation): void
+interface Flags extends OperationFlags {
+  note(note: string): void;
+  onCleanup(operation: Operation): void;
+  onUnhandledRejection(err: Error): void;
+  onUncaughtException(err: Error): void;
 }
 
 interface After {
-  (operation: Operation): void,
-  (options: Options, operation: Operation): void
+  (operation: Operation): void;
+  (options: Options, operation: Operation): void;
 }
 
-interface Before extends After { }
+interface Before extends After {}
 
 interface ScriptOptions {
   /** should execution of tests be delayed until the CLI runs them */
-  schedule?: boolean
-  cli?: any
+  schedule?: boolean;
+  cli?: any;
 }
 
 interface ExperimentOptions extends Options {
   /** skip this experiment */
-  skip?: boolean,
+  skip?: boolean;
   /** only run this experiment/test */
-  only?: boolean
+  only?: boolean;
 }
 
-interface TestOptionsOnlySkip extends Options, Plan { }
+interface TestOptionsOnlySkip extends Options, Plan {}
 
-interface TestOptions extends ExperimentOptions, Plan { }
+interface TestOptions extends ExperimentOptions, Plan {}
 
-interface TestFunction extends Operation {
-  <T>(flags: Flags): Promise<T> | void,
-  (flags: Flags): void
+interface TestFunction {
+  <T>(flags: Flags): Promise<T> | void;
+  (flags: Flags): void;
 }
 
 interface Test {
-  (title: String, test: TestFunction): void,
-  (title: String, options: TestOptions, test: TestFunction): void,
+  (title: String, test: TestFunction): void;
+  (title: String, options: TestOptions, test: TestFunction): void;
   /** only execute this test */
-  only(title: String, test: TestFunction): void,
-  only(title: String, options: TestOptionsOnlySkip, test: TestFunction): void,
+  only(title: String, test: TestFunction): void;
+  only(title: String, options: TestOptionsOnlySkip, test: TestFunction): void;
   /** skip this test */
-  skip(title: String, test: TestFunction): void,
-  skip(title: String, options: TestOptionsOnlySkip, test: TestFunction): void
+  skip(title: String, test: TestFunction): void;
+  skip(title: String, options: TestOptionsOnlySkip, test: TestFunction): void;
 }
 
 interface ExperimentFunction {
-  (title: String, experiment: () => void): void,
-  (title: String, options: ExperimentOptions, experiment: () => void): void
+  (title: String, experiment: () => void): void;
+  (title: String, options: ExperimentOptions, experiment: () => void): void;
 }
 
 interface Experiment extends ExperimentFunction {
   /** only execute this experiment */
-  only: ExperimentFunction,
+  only: ExperimentFunction;
   /** skip this experiment */
-  skip: ExperimentFunction,
+  skip: ExperimentFunction;
 }


### PR DESCRIPTION
The lab documentation describes the use of `flags.context` (https://github.com/hapijs/lab#context) in `before`, `after` and `test`. This applies this documented feature to the typings.